### PR TITLE
Add model aliases environment variable support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,10 +59,11 @@ PERPLEXITY_API_TYPE=openai
 PERPLEXITY_API_NAME=perplexity  # Optional display name
 
 # Model Aliases
-# Define aliases for easier model reference
-GEN_MODEL_LARGE=anthropic:claude-3-5-sonnet-20241022
-GEN_MODEL_FAST=openai:gpt-4o-mini
-GEN_MODEL_SMART=anthropic:claude-3-opus-20240229
+# Define aliases for easier model reference using LM_MODEL_* prefix
+# Usage: model: "large" instead of model: "openai:gpt-4o"
+LM_MODEL_LARGE=anthropic:claude-3-5-sonnet-20241022
+LM_MODEL_FAST=openai:gpt-4o-mini
+LM_MODEL_SMART=anthropic:claude-3-opus-20240229
 
 # Testing Configuration
 MOCK_PROVIDER_ENABLED=true

--- a/README.md
+++ b/README.md
@@ -164,12 +164,14 @@ With these environment variables set, you can use the custom provider in your mo
 You can create model aliases using environment variables to make model selection more flexible and easier to change across your application:
 
 ```bash
-# Define a model alias
-GEN_MODEL_LARGE=zai:glm-4.6
+# Define a model alias using the LM_MODEL_* prefix
+LM_MODEL_LARGE=openai:gpt-4o
+LM_MODEL_FAST=openai:gpt-4o-mini
+LM_MODEL_SMART=anthropic:claude-3-opus-20240229
 ```
 ```ts
 {
-  model: 'large', // Resolves to 'zai:glm-4.6'
+  model: 'large', // Resolves to 'openai:gpt-4o'
 }
 ```
 


### PR DESCRIPTION
Implement the ability to set model aliases through environment variables, allowing users to reference models by simple names instead of provider:modelId format.

Changes:
- Updated resolveModel() to check for LM_MODEL_* env vars when no colon is present
- Supports recursive alias resolution (aliases can point to other aliases)
- Works with all built-in and custom providers
- Case-insensitive alias names (converted to uppercase for env var lookup)
- Added comprehensive test suite with 10 new tests covering various scenarios

Usage:
  Set: LM_MODEL_LARGE=openai:gpt-4o Use: model: "large"

Documentation:
- Updated README.md with correct LM_MODEL_* prefix examples
- Updated .env.example with LM_MODEL_* prefix and usage comment
- Enhanced JSDoc with alias examples

Tests:
- All 24 tests passing including new alias functionality
- Tests cover: simple aliases, chained resolution, case handling, Bedrock models, error messages, and multi-provider support