### PR TITLE
Store defAgent steps as message metadata

### DIFF
--- a/src/__snapshots__/Prompt.test.ts.snap
+++ b/src/__snapshots__/Prompt.test.ts.snap
@@ -382,6 +382,32 @@ exports[`Prompt > should handle defAgent to create a sub-prompt with its own mod
         {
           "content": [
             {
+              "agentSteps": [
+                {
+                  "input": {
+                    "prompt": [
+                      {
+                        "content": [
+                          {
+                            "text": "Please research <researchTopic> with <researchDepth> level of detail.",
+                            "type": "text",
+                          },
+                        ],
+                        "role": "user",
+                      },
+                    ],
+                  },
+                  "output": {
+                    "content": [
+                      {
+                        "text": "Analyzing quantum computing in depth...Quantum computing uses qubits and superposition principles for computation.",
+                        "type": "text",
+                      },
+                    ],
+                    "finishReason": "stop",
+                  },
+                },
+              ],
               "output": {
                 "type": "text",
                 "value": "Analyzing quantum computing in depth...Quantum computing uses qubits and superposition principles for computation.",

--- a/src/__snapshots__/runPrompt.test.ts.snap
+++ b/src/__snapshots__/runPrompt.test.ts.snap
@@ -379,6 +379,32 @@ exports[`runPrompt > should support defAgent for creating hierarchical agent wor
         {
           "content": [
             {
+              "agentSteps": [
+                {
+                  "input": {
+                    "prompt": [
+                      {
+                        "content": [
+                          {
+                            "text": "Validate the following data: <inputData>",
+                            "type": "text",
+                          },
+                        ],
+                        "role": "user",
+                      },
+                    ],
+                  },
+                  "output": {
+                    "content": [
+                      {
+                        "text": "Validating email format...Validating age range...All validations passed.",
+                        "type": "text",
+                      },
+                    ],
+                    "finishReason": "stop",
+                  },
+                },
+              ],
               "output": {
                 "type": "text",
                 "value": "Validating email format...Validating age range...All validations passed.",
@@ -455,6 +481,32 @@ exports[`runPrompt > should support defAgent for creating hierarchical agent wor
         {
           "content": [
             {
+              "agentSteps": [
+                {
+                  "input": {
+                    "prompt": [
+                      {
+                        "content": [
+                          {
+                            "text": "Validate the following data: <inputData>",
+                            "type": "text",
+                          },
+                        ],
+                        "role": "user",
+                      },
+                    ],
+                  },
+                  "output": {
+                    "content": [
+                      {
+                        "text": "Validating email format...Validating age range...All validations passed.",
+                        "type": "text",
+                      },
+                    ],
+                    "finishReason": "stop",
+                  },
+                },
+              ],
               "output": {
                 "type": "text",
                 "value": "Validating email format...Validating age range...All validations passed.",
@@ -487,6 +539,32 @@ exports[`runPrompt > should support defAgent for creating hierarchical agent wor
         {
           "content": [
             {
+              "agentSteps": [
+                {
+                  "input": {
+                    "prompt": [
+                      {
+                        "content": [
+                          {
+                            "text": "Execute <operation> on <inputSource>",
+                            "type": "text",
+                          },
+                        ],
+                        "role": "user",
+                      },
+                    ],
+                  },
+                  "output": {
+                    "content": [
+                      {
+                        "text": "Starting transformation process...Data transformed successfully.",
+                        "type": "text",
+                      },
+                    ],
+                    "finishReason": "stop",
+                  },
+                },
+              ],
               "output": {
                 "type": "text",
                 "value": "Starting transformation process...Data transformed successfully.",


### PR DESCRIPTION
When a defAgent tool is called, its child prompt's steps are now preserved and stored as `agentSteps` metadata in the tool-result message within prompt.steps. This allows inspection of the agent's execution history.

Changes:
- Add _agentStepsMap to track agent steps by toolCallId
- Save agent steps in transformParams before discarding them
- Include agentSteps in the steps getter for tool-result messages