### PR TITLE
Add active tools to prompt steps

### DIFF
--- a/src/__snapshots__/Prompt.test.ts.snap
+++ b/src/__snapshots__/Prompt.test.ts.snap
@@ -3,6 +3,10 @@
 exports[`Prompt > should handle a complete workflow testing all Prompt class features 1`] = `
 [
   {
+    "activeTools": [
+      "database",
+      "formatter",
+    ],
     "input": {
       "prompt": [
         {
@@ -71,6 +75,10 @@ permissions:
     },
   },
   {
+    "activeTools": [
+      "database",
+      "formatter",
+    ],
     "input": {
       "prompt": [
         {
@@ -179,6 +187,10 @@ permissions:
     },
   },
   {
+    "activeTools": [
+      "database",
+      "formatter",
+    ],
     "input": {
       "prompt": [
         {
@@ -317,6 +329,9 @@ permissions:
 exports[`Prompt > should handle composite agents with defAgent array syntax 1`] = `
 [
   {
+    "activeTools": [
+      "specialists",
+    ],
     "input": {
       "prompt": [
         {
@@ -362,6 +377,9 @@ exports[`Prompt > should handle composite agents with defAgent array syntax 1`] 
     },
   },
   {
+    "activeTools": [
+      "specialists",
+    ],
     "input": {
       "prompt": [
         {
@@ -415,6 +433,7 @@ exports[`Prompt > should handle composite agents with defAgent array syntax 1`] 
                       "response": "Researching quantum computing...Quantum computing uses qubits for computation.",
                       "steps": [
                         {
+                          "activeTools": [],
                           "input": {
                             "prompt": [
                               {
@@ -451,6 +470,7 @@ You are a researcher.
                       "response": "Analyzing quantum data...Analysis shows promising results.",
                       "steps": [
                         {
+                          "activeTools": [],
                           "input": {
                             "prompt": [
                               {
@@ -510,6 +530,9 @@ You are an analyst.
 exports[`Prompt > should handle composite tools with defTool array syntax 1`] = `
 [
   {
+    "activeTools": [
+      "file",
+    ],
     "input": {
       "prompt": [
         {
@@ -564,6 +587,9 @@ Appended line",
     },
   },
   {
+    "activeTools": [
+      "file",
+    ],
     "input": {
       "prompt": [
         {
@@ -670,6 +696,9 @@ Appended line",
 exports[`Prompt > should handle defAgent to create a sub-prompt with its own model 1`] = `
 [
   {
+    "activeTools": [
+      "researchAgent",
+    ],
     "input": {
       "prompt": [
         {
@@ -703,6 +732,9 @@ exports[`Prompt > should handle defAgent to create a sub-prompt with its own mod
     },
   },
   {
+    "activeTools": [
+      "researchAgent",
+    ],
     "input": {
       "prompt": [
         {
@@ -737,6 +769,7 @@ exports[`Prompt > should handle defAgent to create a sub-prompt with its own mod
             {
               "agentSteps": [
                 {
+                  "activeTools": [],
                   "input": {
                     "prompt": [
                       {
@@ -807,6 +840,9 @@ Your expertise is in technical topics.
 exports[`Prompt > should handle errors in composite agent sub-calls gracefully 1`] = `
 [
   {
+    "activeTools": [
+      "agents",
+    ],
     "input": {
       "prompt": [
         {
@@ -852,6 +888,9 @@ exports[`Prompt > should handle errors in composite agent sub-calls gracefully 1
     },
   },
   {
+    "activeTools": [
+      "agents",
+    ],
     "input": {
       "prompt": [
         {
@@ -905,6 +944,7 @@ exports[`Prompt > should handle errors in composite agent sub-calls gracefully 1
                       "response": "Working agent response.",
                       "steps": [
                         {
+                          "activeTools": [],
                           "input": {
                             "prompt": [
                               {
@@ -962,6 +1002,9 @@ exports[`Prompt > should handle errors in composite agent sub-calls gracefully 1
 exports[`Prompt > should handle errors in composite tool sub-calls gracefully 1`] = `
 [
   {
+    "activeTools": [
+      "operations",
+    ],
     "input": {
       "prompt": [
         {
@@ -1013,6 +1056,9 @@ exports[`Prompt > should handle errors in composite tool sub-calls gracefully 1`
     },
   },
   {
+    "activeTools": [
+      "operations",
+    ],
     "input": {
       "prompt": [
         {

--- a/src/__snapshots__/StatefulPrompt.test.ts.snap
+++ b/src/__snapshots__/StatefulPrompt.test.ts.snap
@@ -12,6 +12,7 @@ exports[`StatefulPrompt > should allow step modifications from effects 1`] = `
   "stepModifierCalled": true,
   "steps": [
     {
+      "activeTools": [],
       "input": {
         "prompt": [
           {
@@ -32,6 +33,7 @@ exports[`StatefulPrompt > should allow step modifications from effects 1`] = `
 exports[`StatefulPrompt > should create state with defState 1`] = `
 [
   {
+    "activeTools": [],
     "input": {
       "prompt": [
         {
@@ -61,6 +63,9 @@ exports[`StatefulPrompt > should create state with defState 1`] = `
 exports[`StatefulPrompt > should maintain state across re-executions 1`] = `
 [
   {
+    "activeTools": [
+      "testTool",
+    ],
     "input": {
       "prompt": [
         {
@@ -93,6 +98,9 @@ exports[`StatefulPrompt > should maintain state across re-executions 1`] = `
     },
   },
   {
+    "activeTools": [
+      "testTool",
+    ],
     "input": {
       "prompt": [
         {
@@ -176,6 +184,7 @@ exports[`StatefulPrompt > should run effects with dependencies 1`] = `
   "finalDependency": 0,
   "steps": [
     {
+      "activeTools": [],
       "input": {
         "prompt": [
           {
@@ -206,6 +215,7 @@ exports[`StatefulPrompt > should run effects without dependencies on every step 
   ],
   "steps": [
     {
+      "activeTools": [],
       "input": {
         "prompt": [
           {

--- a/src/__snapshots__/StreamText.test.ts.snap
+++ b/src/__snapshots__/StreamText.test.ts.snap
@@ -3,6 +3,9 @@
 exports[`StreamTextBuilder > Integration Test > should handle all features in a comprehensive workflow 1`] = `
 [
   {
+    "activeTools": [
+      "calculator",
+    ],
     "input": {
       "prompt": [
         {
@@ -59,6 +62,10 @@ exports[`StreamTextBuilder > Integration Test > should handle all features in a 
     },
   },
   {
+    "activeTools": [
+      "calculator",
+      "formatter",
+    ],
     "input": {
       "prompt": [
         {
@@ -151,6 +158,10 @@ Use the tools available to you for accuracy.",
     },
   },
   {
+    "activeTools": [
+      "calculator",
+      "formatter",
+    ],
     "input": {
       "prompt": [
         {

--- a/src/__snapshots__/integration.test.ts.snap
+++ b/src/__snapshots__/integration.test.ts.snap
@@ -3,6 +3,13 @@
 exports[`Prompt > should handle a complete workflow testing all Prompt class features 1`] = `
 [
   {
+    "activeTools": [
+      "file",
+      "research",
+      "calculator",
+      "specialists",
+      "synthesizer",
+    ],
     "input": {
       "prompt": [
         {
@@ -73,6 +80,13 @@ completion: Finalize and save results
     },
   },
   {
+    "activeTools": [
+      "file",
+      "research",
+      "calculator",
+      "specialists",
+      "synthesizer",
+    ],
     "input": {
       "prompt": [
         {
@@ -186,6 +200,13 @@ completion: Finalize and save results
     },
   },
   {
+    "activeTools": [
+      "file",
+      "research",
+      "calculator",
+      "specialists",
+      "synthesizer",
+    ],
     "input": {
       "prompt": [
         {
@@ -342,6 +363,13 @@ Key applications in cryptography...",
     },
   },
   {
+    "activeTools": [
+      "file",
+      "research",
+      "calculator",
+      "specialists",
+      "synthesizer",
+    ],
     "input": {
       "prompt": [
         {
@@ -467,6 +495,13 @@ Key applications in cryptography...",
     },
   },
   {
+    "activeTools": [
+      "file",
+      "research",
+      "calculator",
+      "specialists",
+      "synthesizer",
+    ],
     "input": {
       "prompt": [
         {
@@ -519,6 +554,13 @@ You are a technical analyst specializing in deep technical evaluation.
     },
   },
   {
+    "activeTools": [
+      "file",
+      "research",
+      "calculator",
+      "specialists",
+      "synthesizer",
+    ],
     "input": {
       "prompt": [
         {
@@ -604,6 +646,13 @@ You are a technical analyst specializing in deep technical evaluation.
     },
   },
   {
+    "activeTools": [
+      "file",
+      "research",
+      "calculator",
+      "specialists",
+      "synthesizer",
+    ],
     "input": {
       "prompt": [
         {
@@ -723,6 +772,13 @@ The workflow progressed through all phases successfully!",
     },
   },
   {
+    "activeTools": [
+      "file",
+      "research",
+      "calculator",
+      "specialists",
+      "synthesizer",
+    ],
     "input": {
       "prompt": [
         {
@@ -753,6 +809,13 @@ You are a market analyst specializing in commercial trends.
     },
   },
   {
+    "activeTools": [
+      "file",
+      "research",
+      "calculator",
+      "specialists",
+      "synthesizer",
+    ],
     "input": {
       "prompt": [
         {
@@ -850,6 +913,7 @@ I have conducted a comprehensive analysis of Quantum Computing Applications thro
 The workflow progressed through all phases successfully!",
                       "steps": [
                         {
+                          "activeTools": [],
                           "input": {
                             "prompt": [
                               {
@@ -902,6 +966,7 @@ You are a technical analyst specializing in deep technical evaluation.
                           },
                         },
                         {
+                          "activeTools": [],
                           "input": {
                             "prompt": [
                               {
@@ -987,6 +1052,7 @@ You are a technical analyst specializing in deep technical evaluation.
                           },
                         },
                         {
+                          "activeTools": [],
                           "input": {
                             "prompt": [
                               {
@@ -1112,6 +1178,7 @@ The workflow progressed through all phases successfully!",
                       "response": "",
                       "steps": [
                         {
+                          "activeTools": [],
                           "input": {
                             "prompt": [
                               {

--- a/src/__snapshots__/runPrompt.test.ts.snap
+++ b/src/__snapshots__/runPrompt.test.ts.snap
@@ -3,6 +3,10 @@
 exports[`runPrompt > should execute a complete prompt workflow with all features 1`] = `
 [
   {
+    "activeTools": [
+      "getWeather",
+      "convertTemperature",
+    ],
     "input": {
       "prompt": [
         {
@@ -68,6 +72,10 @@ preferredUnit: metric
     },
   },
   {
+    "activeTools": [
+      "getWeather",
+      "convertTemperature",
+    ],
     "input": {
       "prompt": [
         {
@@ -168,6 +176,10 @@ preferredUnit: metric
     },
   },
   {
+    "activeTools": [
+      "getWeather",
+      "convertTemperature",
+    ],
     "input": {
       "prompt": [
         {
@@ -298,6 +310,10 @@ preferredUnit: metric
 exports[`runPrompt > should support defAgent for creating hierarchical agent workflows 1`] = `
 [
   {
+    "activeTools": [
+      "validationAgent",
+      "processingAgent",
+    ],
     "input": {
       "prompt": [
         {
@@ -348,6 +364,10 @@ You are an orchestrator AI that coordinates multiple specialist agents.
     },
   },
   {
+    "activeTools": [
+      "validationAgent",
+      "processingAgent",
+    ],
     "input": {
       "prompt": [
         {
@@ -399,6 +419,7 @@ You are an orchestrator AI that coordinates multiple specialist agents.
             {
               "agentSteps": [
                 {
+                  "activeTools": [],
                   "input": {
                     "prompt": [
                       {
@@ -469,6 +490,10 @@ age: 25
     },
   },
   {
+    "activeTools": [
+      "validationAgent",
+      "processingAgent",
+    ],
     "input": {
       "prompt": [
         {
@@ -520,6 +545,7 @@ You are an orchestrator AI that coordinates multiple specialist agents.
             {
               "agentSteps": [
                 {
+                  "activeTools": [],
                   "input": {
                     "prompt": [
                       {
@@ -591,6 +617,7 @@ age: 25
             {
               "agentSteps": [
                 {
+                  "activeTools": [],
                   "input": {
                     "prompt": [
                       {


### PR DESCRIPTION
Add activeTools array to each step in prompt.steps to track which tools were active during that step's execution.

Changes:
- Add _currentActiveTools field to StreamTextBuilder to track active tools
- Update middleware to capture and store activeTools with each step
- Update prepareStep composition to set _currentActiveTools from PrepareStepResult
- Default to all tools when activeTools is not explicitly set via prepareStep
- Update steps getter to include activeTools in returned step structure
- Add comprehensive tests for activeTools tracking
- Update all snapshots to reflect new step structure

This allows users to see which tools were available to the model during each step, making it easier to understand and debug multi-step workflows.