### PR TITLE
Fix effects running multiple times in test

### DIFF
--- a/src/__snapshots__/defEffect.test.ts.snap
+++ b/src/__snapshots__/defEffect.test.ts.snap
@@ -4,7 +4,6 @@ exports[`defEffect() > filters tools via stepModifier 1`] = `
 [
   {
     "activeTools": [
-      "t1",
       "t2",
     ],
     "input": {
@@ -57,55 +56,6 @@ exports[`defEffect() > filters tools via stepModifier 1`] = `
     ],
     "input": {
       "prompt": [
-        {
-          "content": [
-            {
-              "text": "msg",
-              "type": "text",
-            },
-          ],
-          "role": "user",
-        },
-        {
-          "content": [
-            {
-              "text": "a",
-              "type": "text",
-            },
-            {
-              "input": {
-                "task": "do it",
-              },
-              "toolCallId": "c1",
-              "toolName": "worker",
-              "type": "tool-call",
-            },
-          ],
-          "role": "assistant",
-        },
-        {
-          "content": [
-            {
-              "output": {
-                "type": "error-text",
-                "value": "Model tried to call unavailable tool 'worker'. Available tools: t1, t2.",
-              },
-              "toolCallId": "c1",
-              "toolName": "worker",
-              "type": "tool-result",
-            },
-          ],
-          "role": "tool",
-        },
-        {
-          "content": [
-            {
-              "text": "add message",
-              "type": "text",
-            },
-          ],
-          "role": "user",
-        },
         {
           "content": [
             {

--- a/src/__snapshots__/integration.test.ts.snap
+++ b/src/__snapshots__/integration.test.ts.snap
@@ -16,9 +16,6 @@ exports[`Prompt > should handle a complete workflow testing all Prompt class fea
           "content": "<role>
 role prompt
 </role>
-<guidelines>
-guidelines prompt
-</guidelines>
 <expertise>
 expertise prompt
 </expertise>
@@ -106,9 +103,9 @@ completion: Finalize and save results
     "input": {
       "prompt": [
         {
-          "content": "<role>
-role prompt
-</role>
+          "content": "<guidelines>
+guidelines prompt
+</guidelines>
 <expertise>
 expertise prompt
 </expertise>
@@ -412,9 +409,6 @@ Key applications in cryptography...",
           "content": "<guidelines>
 guidelines prompt
 </guidelines>
-<expertise>
-expertise prompt
-</expertise>
 <variables>
   <RESEARCH_TOPIC>
  Quantum Computing Applications
@@ -737,7 +731,6 @@ You are a market analyst specializing in commercial trends.
     "activeTools": [
       "file",
       "research",
-      "calculator",
       "specialists",
       "synthesizer",
     ],


### PR DESCRIPTION
…iately

Three bugs were fixed in the effects system:

1. Effects were registered multiple times during prompt re-execution. When promptFn was re-executed on subsequent steps, defEffect() was called again, adding duplicate effects to EffectsManager. Now effects are cleared before re-execution, similar to how definitions are handled.

2. activeTools set via disable() was not being propagated to the AI SDK. The _applyStepModifications method only returned activeTools if _stepModifications.tools was set via stepModifier, ignoring the activeTools set by the disable() logic in _processEffects.

3. disable() now takes effect immediately in the same step. Previously, disabled definitions were applied BEFORE effects ran, so disable() only took effect in the next step. Now effects run first, then disabled definitions are applied, so disable() takes effect in the current step.