### PR TITLE
Refactor 02: Test and Build

### DIFF
--- a/src/StatefulPrompt.ts
+++ b/src/StatefulPrompt.ts
@@ -1060,7 +1060,7 @@ Return only the JSON object in your response, without any additional text or exp
           this._clearDefinitions();
 
           // Clear effects so they can be re-registered during re-execution
-          this._effectsManager.clear();
+          this._effectsManager.reset();
 
           // Re-execute promptFn
           const promptMethods = this._getPromptMethods();

--- a/src/definitions/DefinitionTracker.ts
+++ b/src/definitions/DefinitionTracker.ts
@@ -1,3 +1,5 @@
+import { Resettable } from '../types';
+
 /**
  * Definition types that can be tracked
  */
@@ -8,7 +10,7 @@ export type DefinitionType = 'def' | 'defData' | 'defSystem' | 'defTool' | 'defA
  * This enables reconciliation - removing definitions that are no longer defined
  * after a re-execution of the prompt function.
  */
-export class DefinitionTracker {
+export class DefinitionTracker implements Resettable {
   private seen = new Set<string>();
 
   /**

--- a/src/effects/EffectsManager.test.ts
+++ b/src/effects/EffectsManager.test.ts
@@ -67,7 +67,7 @@ describe('EffectsManager', () => {
 
     // Second call with same dep - should not run
     // Need to re-register to update dependencies array reference
-    manager.clear();
+    manager.reset();
     manager.register(callback, [dep]);
     manager.process(context, stepModifier);
     expect(callback).toHaveBeenCalledTimes(2); // First run after clear
@@ -90,7 +90,7 @@ describe('EffectsManager', () => {
     expect(callback).toHaveBeenCalledTimes(1);
 
     // Change the dependency array by clearing and re-registering
-    manager.clear();
+    manager.reset();
     dep = 2;
     manager.register(callback, [dep]);
     manager.process(context, stepModifier);
@@ -107,7 +107,7 @@ describe('EffectsManager', () => {
     manager.process(context, stepModifier);
 
     // Clear and register with different length
-    manager.clear();
+    manager.reset();
     manager.register(callback, [1, 2]);
     manager.process(context, stepModifier);
 
@@ -123,7 +123,7 @@ describe('EffectsManager', () => {
 
     expect(manager.getEffects()).toHaveLength(2);
 
-    manager.clear();
+    manager.reset();
 
     expect(manager.getEffects()).toHaveLength(0);
   });

--- a/src/effects/EffectsManager.ts
+++ b/src/effects/EffectsManager.ts
@@ -1,10 +1,10 @@
-import { Effect, PromptContext, StepModifier } from '../types';
+import { Effect, PromptContext, StepModifier, Resettable } from '../types';
 
 /**
  * EffectsManager handles effect registration and execution.
  * Similar to React's useEffect hook pattern.
  */
-export class EffectsManager {
+export class EffectsManager implements Resettable {
   private effects: Effect[] = [];
   private previousDeps = new Map<number, any[]>();
   private idCounter = 0;
@@ -115,11 +115,18 @@ export class EffectsManager {
   }
 
   /**
-   * Clear all effects and reset state.
+   * Reset the effects manager, clearing all effects and counters.
    */
-  clear(): void {
+  reset(): void {
     this.effects = [];
     this.previousDeps.clear();
     this.idCounter = 0;
+  }
+
+  /**
+   * @deprecated Use reset() instead. Will be removed in next major version.
+   */
+  clear(): void {
+    this.reset();
   }
 }

--- a/src/state/StateManager.test.ts
+++ b/src/state/StateManager.test.ts
@@ -52,7 +52,7 @@ describe('StateManager', () => {
     manager.set('a', 1);
     manager.set('b', 2);
 
-    manager.clear();
+    manager.reset();
 
     expect(manager.has('a')).toBe(false);
     expect(manager.has('b')).toBe(false);

--- a/src/state/StateManager.ts
+++ b/src/state/StateManager.ts
@@ -1,8 +1,10 @@
+import { Resettable } from '../types';
+
 /**
  * StateManager handles state persistence across prompt re-executions.
  * Similar to React's useState hook pattern.
  */
-export class StateManager {
+export class StateManager implements Resettable {
   private store = new Map<string, any>();
 
   /**
@@ -54,9 +56,16 @@ export class StateManager {
   }
 
   /**
-   * Clear all state
+   * Reset the state manager, clearing all stored state.
+   */
+  reset(): void {
+    this.store.clear();
+  }
+
+  /**
+   * @deprecated Use reset() instead. Will be removed in next major version.
    */
   clear(): void {
-    this.store.clear();
+    this.reset();
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,18 @@ export interface DefinitionProxy {
 }
 
 /**
+ * Interface for managers that can be reset to their initial state.
+ * Used by StateManager, EffectsManager, and DefinitionTracker.
+ */
+export interface Resettable {
+  /**
+   * Reset the manager to its initial state.
+   * Clears all stored data and resets any internal counters.
+   */
+  reset(): void;
+}
+
+/**
  * Interface for the prompt context passed to effects
  */
 export interface PromptContext {


### PR DESCRIPTION
Create a shared Resettable interface implemented by StateManager, EffectsManager, and DefinitionTracker to standardize their reset methods. Rename clear() to reset() with deprecated aliases for backward compatibility. Update all callers to use the new reset() method.

Changes:
- Add Resettable interface to src/types.ts
- Update StateManager to implement Resettable and rename clear() to reset()
- Update EffectsManager to implement Resettable and rename clear() to reset()
- Update DefinitionTracker to implement Resettable
- Update StatefulPrompt to use reset() instead of clear()
- Update StateManager and EffectsManager tests to use reset()