### PR TITLE
Refactor 03 and test build

### DIFF
--- a/src/StreamText.ts
+++ b/src/StreamText.ts
@@ -10,6 +10,7 @@ import type {
     ModelMessage
 } from 'ai';
 import { resolveModel, type ModelInput } from './providers/resolver';
+import { PromptError, ErrorCodes } from './errors';
 
 // Helper type for the options object
 export type StreamTextOptions = Parameters<typeof streamText>[0];
@@ -295,7 +296,10 @@ export class StreamTextBuilder {
      */
     public execute(): StreamTextResult<any, any> {
         if (!this._model) {
-            throw new Error('Model is required to execute streamText.');
+            throw new PromptError(
+                'Model is required to execute streamText',
+                ErrorCodes.MODEL_REQUIRED
+            );
         }
 
         // 1. Compose System Prompt

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { resolve } from 'path';
 import { existsSync } from 'fs';
 import { runPrompt } from './runPrompt';
 import { createMockModel, MockContent } from './test/createMockModel';
+import { LmthingError } from './errors';
 
 export const VALID_EXTENSION = '.lmt.mjs';
 
@@ -16,10 +17,11 @@ export interface LmtModule {
   mock?: MockContent[];
 }
 
-export class CliError extends Error {
+export class CliError extends LmthingError {
   constructor(message: string, public exitCode: number = 1) {
-    super(message);
+    super(message, 'CLI_ERROR');
     this.name = 'CliError';
+    Object.setPrototypeOf(this, CliError.prototype);
   }
 }
 

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LmthingError,
+  ProviderError,
+  ValidationError,
+  PluginError,
+  PromptError,
+  ErrorCodes,
+} from './errors';
+
+describe('Error classes', () => {
+  describe('LmthingError', () => {
+    it('creates error with message and code', () => {
+      const error = new LmthingError('test message', 'TEST_CODE');
+      expect(error.message).toBe('test message');
+      expect(error.code).toBe('TEST_CODE');
+      expect(error.name).toBe('LmthingError');
+    });
+
+    it('is an instance of Error', () => {
+      const error = new LmthingError('test', 'CODE');
+      expect(error instanceof Error).toBe(true);
+    });
+
+    it('maintains proper prototype chain for instanceof', () => {
+      const error = new LmthingError('test', 'CODE');
+      expect(error instanceof LmthingError).toBe(true);
+    });
+
+    it('has proper stack trace', () => {
+      const error = new LmthingError('test', 'CODE');
+      expect(error.stack).toBeDefined();
+      expect(error.stack).toContain('LmthingError');
+    });
+  });
+
+  describe('ProviderError', () => {
+    it('creates error with message, code, and details', () => {
+      const details = { provider: 'xyz', available: ['openai', 'anthropic'] };
+      const error = new ProviderError('Unknown provider', 'UNKNOWN_PROVIDER', details);
+      expect(error.message).toBe('Unknown provider');
+      expect(error.code).toBe('UNKNOWN_PROVIDER');
+      expect(error.details).toBe(details);
+      expect(error.name).toBe('ProviderError');
+    });
+
+    it('creates error without details', () => {
+      const error = new ProviderError('Unknown provider', 'UNKNOWN_PROVIDER');
+      expect(error.details).toBeUndefined();
+    });
+
+    it('is instanceof LmthingError', () => {
+      const error = new ProviderError('test', 'CODE');
+      expect(error instanceof LmthingError).toBe(true);
+      expect(error instanceof ProviderError).toBe(true);
+    });
+
+    it('maintains proper prototype chain', () => {
+      const error = new ProviderError('test', 'CODE');
+      expect(error instanceof ProviderError).toBe(true);
+    });
+  });
+
+  describe('ValidationError', () => {
+    it('creates error with message, code, and optional details', () => {
+      const details = { field: 'email', reason: 'invalid format' };
+      const error = new ValidationError('Invalid input', 'INVALID_SCHEMA', details);
+      expect(error.message).toBe('Invalid input');
+      expect(error.code).toBe('INVALID_SCHEMA');
+      expect(error.details).toBe(details);
+      expect(error.name).toBe('ValidationError');
+    });
+
+    it('creates error with default code', () => {
+      const error = new ValidationError('Invalid input');
+      expect(error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('is instanceof LmthingError', () => {
+      const error = new ValidationError('test');
+      expect(error instanceof LmthingError).toBe(true);
+      expect(error instanceof ValidationError).toBe(true);
+    });
+  });
+
+  describe('PluginError', () => {
+    it('creates error with message, plugin name, and code', () => {
+      const error = new PluginError('Plugin init failed', 'taskListPlugin', 'PLUGIN_INIT_FAILED');
+      expect(error.message).toBe('Plugin init failed');
+      expect(error.pluginName).toBe('taskListPlugin');
+      expect(error.code).toBe('PLUGIN_INIT_FAILED');
+      expect(error.name).toBe('PluginError');
+    });
+
+    it('creates error with default code', () => {
+      const error = new PluginError('Plugin failed', 'myPlugin');
+      expect(error.code).toBe('PLUGIN_ERROR');
+    });
+
+    it('is instanceof LmthingError', () => {
+      const error = new PluginError('test', 'plugin');
+      expect(error instanceof LmthingError).toBe(true);
+      expect(error instanceof PluginError).toBe(true);
+    });
+  });
+
+  describe('PromptError', () => {
+    it('creates error with message and code', () => {
+      const error = new PromptError('Execution failed', 'EXECUTION_FAILED');
+      expect(error.message).toBe('Execution failed');
+      expect(error.code).toBe('EXECUTION_FAILED');
+      expect(error.name).toBe('PromptError');
+    });
+
+    it('creates error with default code', () => {
+      const error = new PromptError('Something went wrong');
+      expect(error.code).toBe('PROMPT_ERROR');
+    });
+
+    it('is instanceof LmthingError', () => {
+      const error = new PromptError('test');
+      expect(error instanceof LmthingError).toBe(true);
+      expect(error instanceof PromptError).toBe(true);
+    });
+  });
+
+  describe('Error catching and handling', () => {
+    it('can catch specific error types', () => {
+      try {
+        throw new ProviderError('test', 'CODE');
+      } catch (e) {
+        expect(e instanceof ProviderError).toBe(true);
+        expect(e instanceof LmthingError).toBe(true);
+      }
+    });
+
+    it('can catch base LmthingError', () => {
+      const errors = [
+        new ProviderError('p', 'C1'),
+        new ValidationError('v'),
+        new PluginError('pl', 'plugin'),
+        new PromptError('pr'),
+      ];
+
+      for (const error of errors) {
+        try {
+          throw error;
+        } catch (e) {
+          expect(e instanceof LmthingError).toBe(true);
+        }
+      }
+    });
+
+    it('preserves error type through try-catch', () => {
+      const original = new ProviderError(
+        'Unknown provider: xyz',
+        'UNKNOWN_PROVIDER',
+        { provider: 'xyz' }
+      );
+
+      let caught: any = null;
+      try {
+        throw original;
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(caught).toBe(original);
+      expect(caught instanceof ProviderError).toBe(true);
+      expect(caught.details.provider).toBe('xyz');
+    });
+  });
+
+  describe('ErrorCodes constants', () => {
+    it('has all provider error codes', () => {
+      expect(ErrorCodes.UNKNOWN_PROVIDER).toBe('UNKNOWN_PROVIDER');
+      expect(ErrorCodes.MISSING_API_KEY).toBe('MISSING_API_KEY');
+      expect(ErrorCodes.MISSING_API_BASE).toBe('MISSING_API_BASE');
+      expect(ErrorCodes.PROVIDER_NOT_CONFIGURED).toBe('PROVIDER_NOT_CONFIGURED');
+    });
+
+    it('has all validation error codes', () => {
+      expect(ErrorCodes.INVALID_CONFIG).toBe('INVALID_CONFIG');
+      expect(ErrorCodes.INVALID_SCHEMA).toBe('INVALID_SCHEMA');
+      expect(ErrorCodes.MISSING_REQUIRED).toBe('MISSING_REQUIRED');
+    });
+
+    it('has all prompt error codes', () => {
+      expect(ErrorCodes.MODEL_REQUIRED).toBe('MODEL_REQUIRED');
+      expect(ErrorCodes.EXECUTION_FAILED).toBe('EXECUTION_FAILED');
+    });
+
+    it('has all plugin error codes', () => {
+      expect(ErrorCodes.PLUGIN_INIT_FAILED).toBe('PLUGIN_INIT_FAILED');
+      expect(ErrorCodes.PLUGIN_METHOD_FAILED).toBe('PLUGIN_METHOD_FAILED');
+    });
+
+    it('can be used with errors', () => {
+      const error = new ProviderError('test', ErrorCodes.UNKNOWN_PROVIDER);
+      expect(error.code).toBe(ErrorCodes.UNKNOWN_PROVIDER);
+    });
+  });
+
+  describe('Error messages', () => {
+    it('preserves error messages exactly', () => {
+      const messages = [
+        'Simple message',
+        'Message with special chars: @#$%^&*()',
+        'Message with newlines\nand\ttabs',
+        'Message with unicode: 日本語',
+      ];
+
+      for (const message of messages) {
+        const error = new LmthingError(message, 'CODE');
+        expect(error.message).toBe(message);
+      }
+    });
+
+    it('handles empty messages', () => {
+      const error = new LmthingError('', 'CODE');
+      expect(error.message).toBe('');
+    });
+  });
+
+  describe('Error serialization', () => {
+    it('provides useful error info', () => {
+      const error = new ProviderError(
+        'Unknown provider: xyz',
+        'UNKNOWN_PROVIDER',
+        { provider: 'xyz', available: ['openai', 'anthropic'] }
+      );
+
+      expect(error.toString()).toContain('ProviderError');
+      expect(error.message).toBe('Unknown provider: xyz');
+      expect(error.code).toBe('UNKNOWN_PROVIDER');
+    });
+
+    it('includes error name correctly', () => {
+      const errors = [
+        { error: new LmthingError('m', 'c'), expected: 'LmthingError' },
+        { error: new ProviderError('m', 'c'), expected: 'ProviderError' },
+        { error: new ValidationError('m'), expected: 'ValidationError' },
+        { error: new PluginError('m', 'p'), expected: 'PluginError' },
+        { error: new PromptError('m'), expected: 'PromptError' },
+      ];
+
+      for (const { error, expected } of errors) {
+        expect(error.name).toBe(expected);
+      }
+    });
+  });
+
+  describe('Multiple inheritance patterns', () => {
+    it('works with spread operator on error details', () => {
+      const details = { field: 'email', value: 'invalid' };
+      const error = new ProviderError('test', 'CODE', { ...details, extra: 'info' });
+      expect(error.details?.field).toBe('email');
+      expect(error.details?.extra).toBe('info');
+    });
+
+    it('allows null/undefined details', () => {
+      const e1 = new ProviderError('test', 'CODE', undefined);
+      expect(e1.details).toBeUndefined();
+
+      const e2 = new ProviderError('test', 'CODE', null as any);
+      expect(e2.details).toBeNull();
+    });
+  });
+});

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,116 @@
+/**
+ * Custom error classes for lmthing library.
+ * Provides typed, catchable errors with error codes and structured details.
+ */
+
+/**
+ * Base error class for all lmthing errors.
+ * Provides consistent error structure with error codes.
+ */
+export class LmthingError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string
+  ) {
+    super(message);
+    this.name = 'LmthingError';
+    // Maintains proper prototype chain for instanceof checks
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Error thrown when provider resolution fails.
+ *
+ * @example
+ * ```typescript
+ * throw new ProviderError(
+ *   'Unknown provider: xyz',
+ *   'UNKNOWN_PROVIDER',
+ *   { provider: 'xyz', available: ['openai', 'anthropic'] }
+ * );
+ * ```
+ */
+export class ProviderError extends LmthingError {
+  constructor(
+    message: string,
+    code: string,
+    public readonly details?: Record<string, any>
+  ) {
+    super(message, code);
+    this.name = 'ProviderError';
+    Object.setPrototypeOf(this, ProviderError.prototype);
+  }
+}
+
+/**
+ * Error thrown when input validation fails.
+ * Used for schema validation, config validation, etc.
+ */
+export class ValidationError extends LmthingError {
+  constructor(
+    message: string,
+    code: string = 'VALIDATION_ERROR',
+    public readonly details?: Record<string, any>
+  ) {
+    super(message, code);
+    this.name = 'ValidationError';
+    Object.setPrototypeOf(this, ValidationError.prototype);
+  }
+}
+
+/**
+ * Error thrown when a plugin fails.
+ */
+export class PluginError extends LmthingError {
+  constructor(
+    message: string,
+    public readonly pluginName: string,
+    code: string = 'PLUGIN_ERROR'
+  ) {
+    super(message, code);
+    this.name = 'PluginError';
+    Object.setPrototypeOf(this, PluginError.prototype);
+  }
+}
+
+/**
+ * Error thrown when prompt execution fails.
+ */
+export class PromptError extends LmthingError {
+  constructor(
+    message: string,
+    code: string = 'PROMPT_ERROR'
+  ) {
+    super(message, code);
+    this.name = 'PromptError';
+    Object.setPrototypeOf(this, PromptError.prototype);
+  }
+}
+
+/**
+ * Error codes used throughout lmthing.
+ * Use these constants instead of string literals for consistency.
+ */
+export const ErrorCodes = {
+  // Provider errors
+  UNKNOWN_PROVIDER: 'UNKNOWN_PROVIDER',
+  MISSING_API_KEY: 'MISSING_API_KEY',
+  MISSING_API_BASE: 'MISSING_API_BASE',
+  PROVIDER_NOT_CONFIGURED: 'PROVIDER_NOT_CONFIGURED',
+
+  // Validation errors
+  INVALID_CONFIG: 'INVALID_CONFIG',
+  INVALID_SCHEMA: 'INVALID_SCHEMA',
+  MISSING_REQUIRED: 'MISSING_REQUIRED',
+
+  // Prompt errors
+  MODEL_REQUIRED: 'MODEL_REQUIRED',
+  EXECUTION_FAILED: 'EXECUTION_FAILED',
+
+  // Plugin errors
+  PLUGIN_INIT_FAILED: 'PLUGIN_INIT_FAILED',
+  PLUGIN_METHOD_FAILED: 'PLUGIN_METHOD_FAILED',
+} as const;
+
+export type ErrorCode = typeof ErrorCodes[keyof typeof ErrorCodes];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,16 @@
 export { runPrompt, createPluginArray } from './runPrompt';
 
+// Export error classes
+export {
+  LmthingError,
+  ProviderError,
+  ValidationError,
+  PluginError,
+  PromptError,
+  ErrorCodes,
+  type ErrorCode
+} from './errors';
+
 // Export prompt functionality (StatefulPrompt is now the main Prompt class)
 export {
   StatefulPrompt,

--- a/src/providers/resolver.ts
+++ b/src/providers/resolver.ts
@@ -1,6 +1,7 @@
 import { LanguageModelV2 } from '@ai-sdk/provider';
 import { providers } from './index';
 import { getCustomProvider, isCustomProvider, listCustomProviders } from './custom';
+import { ProviderError, ErrorCodes } from '../errors';
 
 /**
  * Resolves a model identifier to a LanguageModelV2 instance
@@ -51,8 +52,10 @@ export function resolveModel(model: LanguageModelV2 | string): LanguageModelV2 {
       return resolveModel(aliasValue);
     }
 
-    throw new Error(
-      `Model alias "${model}" not found. Please set the environment variable ${aliasKey} (e.g., ${aliasKey}=openai:gpt-4o)`
+    throw new ProviderError(
+      `Model alias "${model}" not found. Please set the environment variable ${aliasKey} (e.g., ${aliasKey}=openai:gpt-4o)`,
+      ErrorCodes.PROVIDER_NOT_CONFIGURED,
+      { alias: model, envVar: aliasKey }
     );
   }
 
@@ -80,10 +83,12 @@ export function resolveModel(model: LanguageModelV2 | string): LanguageModelV2 {
   // Provider not found
   const builtInProviders = Object.keys(providers);
   const customProviders = listCustomProviders();
-  const allProviders = [...builtInProviders, ...customProviders].join(', ');
+  const allProviders = [...builtInProviders, ...customProviders];
 
-  throw new Error(
-    `Unknown provider: "${providerName}". Available providers: ${allProviders}`
+  throw new ProviderError(
+    `Unknown provider: "${providerName}". Available providers: ${allProviders.join(', ')}`,
+    ErrorCodes.UNKNOWN_PROVIDER,
+    { provider: providerName, available: allProviders }
   );
 }
 


### PR DESCRIPTION
Implement a comprehensive error class hierarchy to replace generic Error objects throughout the codebase, enabling type-safe error catching and improved debugging.

Changes:
- Create LmthingError base class with error codes for all library errors
- Add specialized error classes: ProviderError, ValidationError, PluginError, PromptError
- Update src/providers/resolver.ts to use ProviderError for unknown providers
- Update src/StreamText.ts to use PromptError for missing model
- Update src/cli.ts to extend LmthingError for CLI errors
- Export error classes from src/index.ts for public API
- Add comprehensive test suite for error classes (31 new tests)

Benefits:
- Type-safe error handling with instanceof checks
- Structured error details for programmatic error handling
- Consistent error codes for all error scenarios
- Better error messages and debugging information
- All 227 tests pass, build successful