### PR TITLE
Propose refactors to improve codebase developer experience

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,13 +24,24 @@ export {
 
 // Export types for the stateful prompt system
 export type {
+  // Core types
   DefinitionProxy,
   PromptContext,
+  LastToolInfo,
+  ZodSchema,
+  // Collection types
   ToolCollection,
   SystemCollection,
   VariableCollection,
-  LastToolInfo,
+  SystemEntry,
+  VariableEntry,
+  VariableType,
+  ToolEntry,
+  // Effect types
   StepModifier,
+  StepModifierItems,
+  Effect,
+  StepModifications,
   // Tool options & callbacks
   ToolOptions,
   ToolEventCallback,
@@ -43,6 +54,9 @@ export type {
   MergePlugins,
   PromptWithPlugins
 } from './types/index';
+
+// Export definition types for advanced usage
+export type { DefinitionType } from './definitions';
 
 // Export PromptConfig from runPrompt
 export type { PromptConfig } from './runPrompt';

--- a/src/types/agents.ts
+++ b/src/types/agents.ts
@@ -3,6 +3,8 @@
  */
 
 import type { Plugin } from './plugins';
+import type { ZodSchema } from './core';
+import type { ModelInput } from '../providers/resolver';
 
 /**
  * Options for defAgent and agent functions
@@ -15,9 +17,9 @@ import type { Plugin } from './plugins';
  * @property plugins - Additional plugins for the agent context
  */
 export interface AgentOptions {
-  model?: any;  // ModelInput from providers/resolver
-  responseSchema?: any;  // Zod schema
+  model?: ModelInput;
+  responseSchema?: ZodSchema;
   system?: string;
   plugins?: readonly Plugin[];
-  [key: string]: any;  // Allow additional options
+  [key: string]: unknown;  // Allow additional options
 }

--- a/src/types/collections.ts
+++ b/src/types/collections.ts
@@ -3,15 +3,54 @@
  */
 
 /**
+ * A named system prompt section
+ *
+ * @category Types
+ */
+export interface SystemEntry {
+  name: string;
+  value: string;
+}
+
+/**
+ * Variable type distinguishes between text (def) and data (defData) definitions
+ *
+ * @category Types
+ */
+export type VariableType = 'text' | 'data';
+
+/**
+ * A variable definition with type information
+ *
+ * @category Types
+ */
+export interface VariableEntry {
+  name: string;
+  type: VariableType | (string & {});  // Allows 'text'|'data' with autocomplete, but accepts any string
+  value: unknown;
+}
+
+/**
+ * A tool entry with name and tool definition
+ * Tool definition follows AI SDK's tool structure
+ *
+ * @category Types
+ */
+export interface ToolEntry {
+  name: string;
+  [key: string]: unknown;  // Tool properties vary based on definition
+}
+
+/**
  * Collection utility for tools
  *
  * @category Types
  */
 export interface ToolCollection {
   has(name: string): boolean;
-  filter(predicate: (tool: any) => boolean): any[];
-  [Symbol.iterator](): Iterator<any>;
-  map<U>(callback: (tool: any) => U): U[];
+  filter(predicate: (entry: ToolEntry) => boolean): ToolEntry[];
+  [Symbol.iterator](): Iterator<ToolEntry>;
+  map<U>(callback: (entry: ToolEntry) => U): U[];
 }
 
 /**
@@ -21,9 +60,9 @@ export interface ToolCollection {
  */
 export interface SystemCollection {
   has(name: string): boolean;
-  filter(predicate: (system: { name: string; value: string }) => boolean): { name: string; value: string }[];
-  [Symbol.iterator](): Iterator<{ name: string; value: string }>;
-  map<U>(callback: (system: { name: string; value: string }) => U): U[];
+  filter(predicate: (system: SystemEntry) => boolean): SystemEntry[];
+  [Symbol.iterator](): Iterator<SystemEntry>;
+  map<U>(callback: (system: SystemEntry) => U): U[];
 }
 
 /**
@@ -33,7 +72,7 @@ export interface SystemCollection {
  */
 export interface VariableCollection {
   has(name: string): boolean;
-  filter(predicate: (variable: { name: string; type: string; value: any }) => boolean): { name: string; type: string; value: any }[];
-  [Symbol.iterator](): Iterator<{ name: string; type: string; value: any }>;
-  map<U>(callback: (variable: { name: string; type: string; value: any }) => U): U[];
+  filter(predicate: (variable: VariableEntry) => boolean): VariableEntry[];
+  [Symbol.iterator](): Iterator<VariableEntry>;
+  map<U>(callback: (variable: VariableEntry) => U): U[];
 }

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -2,7 +2,16 @@
  * Core type definitions for lmthing prompts.
  */
 
+import type { ZodType } from 'zod';
 import type { ToolCollection, SystemCollection, VariableCollection } from './collections';
+
+/**
+ * Type alias for Zod schemas used in tool and agent definitions.
+ * Using ZodType<any> allows any Zod schema while providing basic type info.
+ *
+ * @category Types
+ */
+export type ZodSchema<T = any> = ZodType<T>;
 
 /**
  * Interface for the proxy objects returned by def, defSystem, defTool, defAgent

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -2,16 +2,30 @@
  * Effect system type definitions.
  */
 
+import type { CoreMessage } from 'ai';
 import type { PromptContext } from './core';
+import type { SystemEntry, VariableEntry, ToolEntry } from './collections';
+
+/**
+ * Items that can be added via step modifier for each aspect
+ *
+ * @category Hooks
+ */
+export type StepModifierItems = {
+  messages: CoreMessage[];
+  tools: ToolEntry[];
+  systems: SystemEntry[];
+  variables: VariableEntry[];
+};
 
 /**
  * Step modifier function type
  *
  * @category Hooks
  */
-export type StepModifier = (
-  aspect: 'messages' | 'tools' | 'systems' | 'variables',
-  items: any[]
+export type StepModifier = <K extends keyof StepModifierItems>(
+  aspect: K,
+  items: StepModifierItems[K]
 ) => void;
 
 /**
@@ -22,7 +36,7 @@ export type StepModifier = (
 export interface Effect {
   id: number;
   callback: (prompt: PromptContext, step: StepModifier) => void;
-  dependencies?: any[];
+  dependencies?: unknown[];
 }
 
 /**
@@ -31,8 +45,8 @@ export interface Effect {
  * @category Types
  */
 export interface StepModifications {
-  messages?: any[];
-  tools?: any[];
-  systems?: { name: string; value: string }[];
-  variables?: { name: string; type: string; value: any }[];
+  messages?: CoreMessage[];
+  tools?: ToolEntry[];
+  systems?: SystemEntry[];
+  variables?: VariableEntry[];
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,19 +3,27 @@
  *
  * This file re-exports all types for backward compatibility.
  * Types are organized into focused modules:
- * - core.ts: PromptContext, DefinitionProxy, LastToolInfo, Resettable
- * - collections.ts: ToolCollection, SystemCollection, VariableCollection
+ * - core.ts: PromptContext, DefinitionProxy, LastToolInfo, Resettable, ZodSchema
+ * - collections.ts: ToolCollection, SystemCollection, VariableCollection, SystemEntry, VariableEntry, ToolEntry
  * - tools.ts: ToolOptions, ToolEventCallback, ToolCallbackResult
  * - agents.ts: AgentOptions
- * - effects.ts: Effect, StepModifier, StepModifications
+ * - effects.ts: Effect, StepModifier, StepModifications, StepModifierItems
  * - plugins.ts: Plugin, PluginMethod, MergePlugins, PromptWithPlugins
  */
 
 // Core types
-export type { DefinitionProxy, Resettable, LastToolInfo, PromptContext } from './core';
+export type { DefinitionProxy, Resettable, LastToolInfo, PromptContext, ZodSchema } from './core';
 
-// Collection types
-export type { ToolCollection, SystemCollection, VariableCollection } from './collections';
+// Collection types (including entry types for advanced usage)
+export type {
+  ToolCollection,
+  SystemCollection,
+  VariableCollection,
+  SystemEntry,
+  VariableEntry,
+  VariableType,
+  ToolEntry
+} from './collections';
 
 // Tool types
 export type { ToolCallbackResult, ToolEventCallback, ToolOptions } from './tools';
@@ -24,7 +32,7 @@ export type { ToolCallbackResult, ToolEventCallback, ToolOptions } from './tools
 export type { AgentOptions } from './agents';
 
 // Effect types
-export type { StepModifier, Effect, StepModifications } from './effects';
+export type { StepModifier, Effect, StepModifications, StepModifierItems } from './effects';
 
 // Plugin types
 export type { PluginMethod, Plugin, MergePlugins, PromptWithPlugins } from './plugins';

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -2,6 +2,8 @@
  * Tool-related type definitions.
  */
 
+import type { ZodSchema } from './core';
+
 /**
  * Result returned by tool callbacks (beforeCall, onSuccess, onError)
  * - undefined: output is returned as is
@@ -10,29 +12,38 @@
  *
  * @category Tools
  */
-export type ToolCallbackResult = undefined | string | Record<string, any>;
+export type ToolCallbackResult = undefined | string | Record<string, unknown>;
 
 /**
- * Tool event callback signature
+ * Tool event callback signature with optional generics
  * Receives input and output, returns optional modified output
+ *
+ * @typeParam TInput - Tool input type (defaults to unknown for safety)
+ * @typeParam TOutput - Tool output type (defaults to unknown for safety)
  *
  * @category Tools
  */
-export type ToolEventCallback = (input: any, output: any) => Promise<ToolCallbackResult> | ToolCallbackResult;
+export type ToolEventCallback<TInput = unknown, TOutput = unknown> = (
+  input: TInput,
+  output: TOutput
+) => Promise<ToolCallbackResult> | ToolCallbackResult;
 
 /**
  * Options for defTool and tool functions
  *
  * @category Tools
  *
+ * @typeParam TInput - Tool input type for callbacks
+ * @typeParam TOutput - Tool output type for callbacks
+ *
  * @property responseSchema - Optional Zod schema for validating/formatting tool responses
  * @property onSuccess - Callback fired when tool executes successfully
  * @property onError - Callback fired when tool throws an error
  * @property beforeCall - Callback fired before tool execution
  */
-export interface ToolOptions {
-  responseSchema?: any;  // Zod schema
-  onSuccess?: ToolEventCallback;
-  onError?: ToolEventCallback;
-  beforeCall?: ToolEventCallback;
+export interface ToolOptions<TInput = unknown, TOutput = unknown> {
+  responseSchema?: ZodSchema;
+  onSuccess?: ToolEventCallback<TInput, TOutput>;
+  onError?: ToolEventCallback<TInput, Error | unknown>;
+  beforeCall?: ToolEventCallback<TInput, undefined>;
 }


### PR DESCRIPTION
- Add ZodSchema type alias in types/core.ts for self-documenting schema types
- Replace any with ModelInput type in types/agents.ts for better IDE support
- Add named types (SystemEntry, VariableEntry, VariableType, ToolEntry) in collections
- Improve type safety with generic ToolEventCallback<TInput, TOutput> and ToolOptions
- Update StepModifier with typed StepModifierItems for better autocomplete
- Export additional types: ZodSchema, Effect, StepModifications, StepModifierItems, DefinitionType, SystemEntry, VariableEntry, VariableType, ToolEntry
- Replace any with unknown in several places for safer typing